### PR TITLE
now it does't raise error if a cookie has no value

### DIFF
--- a/lib/rack/cleancookies.rb
+++ b/lib/rack/cleancookies.rb
@@ -7,7 +7,7 @@ module Rack
   module CleanCookies
     # Tests whether a string may be decoded as a form component
     def decodable?(string)
-      URI.decode_www_form_component(string)
+      string && URI.decode_www_form_component(string)
       true
     rescue ArgumentError => e
       /^invalid %-encoding \(.*\)$/.match(e.message) ? false : raise

--- a/test/unit/cleancookies_test.rb
+++ b/test/unit/cleancookies_test.rb
@@ -5,6 +5,7 @@ module Rack
     class RackTest < Test::Unit::TestCase
       COOKIE_OK = 'okcookie=okvalue'
       BAD_COOKIE = 'badcookie=1%G15%G%G1335185427000%G%G%G%G%G'
+      BAD_EMPTY_COOKIE = 'badcookie_empty'
 
       def setup
         @errors = StringIO.new
@@ -23,6 +24,10 @@ module Rack
 
         assert_empty @env['HTTP_COOKIE']
         assert_empty @errors.string
+      end
+
+      def test_empty_cookie_doesnt_raise
+        assert_nothing_raised { process BAD_EMPTY_COOKIE }
       end
 
       def test_rack_errors_if_verbose


### PR DESCRIPTION
It makes working also a bad case like this one: curl 'http://www.xxx.yyy/' -H 'Cookie: user=dfwsefwerfwe; somethingmalformed; wt3_eid=dfeefd'
